### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,13 @@ jobs:
 
       - run: ./cc-test-reporter before-build
       - run: yarn install
+      # run tests!
+      - run: yarn test
       - run: ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
-      # run tests!
-      - run: yarn test
 
 


### PR DESCRIPTION
Hey there, Dave here with Code Climate Support. It seems that you were running your tests **after** you called `upload-coverage`; thus, coverage info was not yet available when the reporter attempted to upload to Code Climate. This PR moves `run: yarn test` to **before** `after-build`. Testing this out on [my own fork](https://github.com/davehenton/config-extended/blob/master/.circleci/config.yml) seemed to work as expected.